### PR TITLE
Patchset to optimize audio latency

### DIFF
--- a/src/jclient.c
+++ b/src/jclient.c
@@ -230,6 +230,7 @@ jclient_j2o (struct jclient *jclient)
   else
     {
       error_print ("j2o: Audio ring buffer overflow. Discarding data...\n");
+      jack_ringbuffer_reset (jclient->ob.j2o_rb);
     }
 }
 

--- a/src/jclient.c
+++ b/src/jclient.c
@@ -476,34 +476,32 @@ jclient_process_cb (jack_nframes_t nframes, void *arg)
   //o2j
 
   f = jclient->o2j_buf_out;
-  for (int i = 0; i < jclient->ob.device_desc.outputs; i++)
-    {
-      buffer[i] = jack_port_get_buffer (jclient->output_ports[i], nframes);
-    }
+  pthread_spin_lock (&jclient->ob.lock);
   for (int i = 0; i < nframes; i++)
     {
-      for (int j = 0; j < jclient->ob.device_desc.outputs; j++)
-	{
-	  buffer[j][i] = *f;
-	  f++;
-	}
+      for (int j  = 0; j < jclient->ob.device_desc.outputs; j++)
+        {
+          buffer[j] = jack_port_get_buffer (jclient->output_ports[j], nframes);
+          buffer[j][i] = *f;
+          f++;
+        }
     }
+  pthread_spin_unlock (&jclient->ob.lock);
 
   //j2o
 
   f = jclient->j2o_aux;
-  for (int i = 0; i < jclient->ob.device_desc.inputs; i++)
-    {
-      buffer[i] = jack_port_get_buffer (jclient->input_ports[i], nframes);
-    }
+  pthread_spin_lock (&jclient->ob.lock);
   for (int i = 0; i < nframes; i++)
     {
       for (int j = 0; j < jclient->ob.device_desc.inputs; j++)
-	{
-	  *f = buffer[j][i];
-	  f++;
-	}
+        {
+          buffer[j] = jack_port_get_buffer (jclient->input_ports[j], nframes);
+         *f = buffer[j][i];
+          f++;
+        }
     }
+  pthread_spin_unlock (&jclient->ob.lock);
 
   jclient_j2o (jclient);
 

--- a/src/overbridge.c
+++ b/src/overbridge.c
@@ -375,6 +375,9 @@ cb_xfr_in_midi (struct libusb_transfer *xfr)
 {
   struct ob_midi_event event;
   int length;
+  struct timespec sleeptime;
+  int sleep_time_ns = SAMPLE_TIME_NS * 1000 ;  //Average wait time
+  sleeptime.tv_nsec = sleep_time_ns;
   overbridge_status_t status;
   struct overbridge *ob = xfr->user_data;
 
@@ -413,6 +416,7 @@ cb_xfr_in_midi (struct libusb_transfer *xfr)
 		}
 	    }
 	  length += OB_MIDI_EVENT_SIZE;
+	  nanosleep(&sleeptime, NULL);
 	}
     }
   else

--- a/src/overbridge.c
+++ b/src/overbridge.c
@@ -745,7 +745,7 @@ overbridge_run (struct overbridge *ob, jack_client_t * client, int priority)
   max_bufsize =
     ob->frames_per_transfer >
     ob->jbufsize ? ob->frames_per_transfer : ob->jbufsize;
-  ob->j2o_rb = jack_ringbuffer_create (max_bufsize * ob->j2o_frame_bytes * 8);
+  ob->j2o_rb = jack_ringbuffer_create (max_bufsize * ob->j2o_frame_bytes * 8 * ob->device_desc.outputs);
   jack_ringbuffer_mlock (ob->j2o_rb);
   ob->o2j_rb = jack_ringbuffer_create (max_bufsize * ob->o2j_frame_bytes * 8);
   jack_ringbuffer_mlock (ob->o2j_rb);

--- a/src/overbridge.h
+++ b/src/overbridge.h
@@ -207,7 +207,8 @@ struct overbridge
   pthread_spinlock_t lock;
   overbridge_status_t status;
   size_t j2o_latency;
-  pthread_t audio_and_o2j_midi;
+  pthread_t audio;
+  pthread_t o2j_midi;
   pthread_t midi_tinfo;
   int priority;
   uint16_t s_counter;

--- a/src/overwitch.c
+++ b/src/overwitch.c
@@ -125,7 +125,7 @@ main (int argc, char *argv[])
 	case 'b':
 	  blocks_per_transfer = (int) strtol (optarg, &endstr, 10);
 	  if (errno || endstr == optarg || *endstr != '\0'
-	      || blocks_per_transfer < 2 || blocks_per_transfer > 32)
+	      || blocks_per_transfer < 2 || blocks_per_transfer > 640)
 	    {
 	      blocks_per_transfer = DEFAULT_BLOCKS;
 	      fprintf (stderr,


### PR DESCRIPTION
With this patchset I am now able to run without any audio crackling with 32 or even 24 blocks per transfer. I identified the main reason for the problems I had before to be reading of incoming MIDI, so cf3a4310424 probably hast most effect. I broke down the changes in little commits as far as possible so you can review and decide for your self what is good and effective. I am not sure about either ;)