### PR TITLE
Skip writing to the device if no audio in ports are connected

### DIFF
--- a/src/jclient.c
+++ b/src/jclient.c
@@ -474,33 +474,27 @@ jclient_process_cb (jack_nframes_t nframes, void *arg)
   //o2j
 
   f = jclient->o2j_buf_out;
-  for (int i = 0; i < jclient->ob.device_desc.outputs; i++)
-    {
-      buffer[i] = jack_port_get_buffer (jclient->output_ports[i], nframes);
-    }
   for (int i = 0; i < nframes; i++)
     {
-      for (int j = 0; j < jclient->ob.device_desc.outputs; j++)
-	{
-	  buffer[j][i] = *f;
-	  f++;
-	}
+      for (int j  = 0; j < jclient->ob.device_desc.outputs; j++)
+        {
+          buffer[j] = jack_port_get_buffer (jclient->output_ports[j], nframes);
+          buffer[j][i] = *f;
+          f++;
+        }
     }
 
   //j2o
 
   f = jclient->j2o_aux;
-  for (int i = 0; i < jclient->ob.device_desc.inputs; i++)
-    {
-      buffer[i] = jack_port_get_buffer (jclient->input_ports[i], nframes);
-    }
   for (int i = 0; i < nframes; i++)
     {
       for (int j = 0; j < jclient->ob.device_desc.inputs; j++)
-	{
-	  *f = buffer[j][i];
-	  f++;
-	}
+        {
+          buffer[j] = jack_port_get_buffer (jclient->input_ports[j], nframes);
+         *f = buffer[j][i];
+          f++;
+        }
     }
 
   jclient_j2o (jclient);

--- a/src/jclient.c
+++ b/src/jclient.c
@@ -491,9 +491,15 @@ jclient_process_cb (jack_nframes_t nframes, void *arg)
     {
       for (int j = 0; j < jclient->ob.device_desc.inputs; j++)
         {
-          buffer[j] = jack_port_get_buffer (jclient->input_ports[j], nframes);
-         *f = buffer[j][i];
-          f++;
+          if (jack_port_connected(jclient->input_ports[j])) {
+            buffer[j] = jack_port_get_buffer (jclient->input_ports[j], nframes);
+           *f = buffer[j][i];
+            f++;
+	  }
+	    else
+	  {
+	    continue;
+	  }
         }
     }
 


### PR DESCRIPTION
This patch set optimizes (or tries to) the handling of audio out to Elektron devices in that it checks if these ports are connected via jack and only then writes out the data to the ring buffer.