### PR TITLE
fix: use alt interface with higher max packet size

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -618,7 +618,7 @@ ow_engine_init (struct ow_engine *engine, int blocks_per_transfer)
       ret = OW_USB_ERROR_CANT_CLAIM_IF;
       goto end;
     }
-  err = libusb_set_interface_alt_setting (engine->usb.device_handle, 2, 2);
+  err = libusb_set_interface_alt_setting (engine->usb.device_handle, 2, 3);
   if (LIBUSB_SUCCESS != err)
     {
       ret = OW_USB_ERROR_CANT_SET_ALT_SETTING;


### PR DESCRIPTION
I think based on the lsusb outputs for our devices, I think 2 is possibly the class compliant one, and 3 is the Overbridge variant? A guess at best. Considering it seems to be present on 4 of the modern devices we have tested (DT, ST, AHmk2, A4mk2), it should be safe to assume it'd be the same on the others.