### PR TITLE
AC_PROG_LIBTOOL is deprecated, use LT_INIT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,9 @@ AC_PREREQ([2.69])
 AC_INIT([overwitch],[1.0],[dagargo@gmail.com])
 AC_CONFIG_SRCDIR([src])
 AC_CONFIG_HEADERS([config.h])
-AM_PROG_LIBTOOL
+# AC_PROG_LIBTOOL is deprecated, use LT_INIT. SD 10/2
+#AC_PROG_LIBTOOL
+LT_INIT
 AC_SEARCH_LIBS([sqrt], [m])
 AC_CONFIG_MACRO_DIRS([m4])
 AM_INIT_AUTOMAKE([1.12 subdir-objects])


### PR DESCRIPTION
AC_PROG_LIBTOOL is outdated; updated to LT_INIT. Tested on Tumbleweed & Fedora.